### PR TITLE
Fixing bug by adding node update permission

### DIFF
--- a/manifests/generated/machine-remediation.yaml.in
+++ b/manifests/generated/machine-remediation.yaml.in
@@ -39,6 +39,7 @@ rules:
   resources:
   - nodes
   verbs:
+  - update
   - delete
   - get
   - list

--- a/pkg/components/rbac.go
+++ b/pkg/components/rbac.go
@@ -50,6 +50,7 @@ var (
 					"nodes",
 				},
 				Verbs: []string{
+					"update",
 					"delete",
 					"get",
 					"list",


### PR DESCRIPTION
When unhealthy node is detected mr controller is having the following error:
E0119 13:02:29.049025       1 machineremediation_controller.go:106] Remediation reboot acion for MachineRemediation remediation-7ktnk failed with error: nodes "worker-0" is forbidden: User "system:serviceaccount:openshift-machine-api:machine-remediation" cannot update resource "nodes" in API group "" at the cluster scope

This PR adds node update permission to resolve this.

Signed-off-by: Nir <niry@redhat.com>